### PR TITLE
add required option -userid to help text

### DIFF
--- a/apg_run_script/apg_run_script.pl
+++ b/apg_run_script/apg_run_script.pl
@@ -346,7 +346,7 @@ sub st_shell_reconf_mgmt{
 		$sth->execute() or die "ERROR ----> st_shell_reconf_mgmt ----> Error while executing the DB query with message : " . $sth->errstr() . "\n";
 		my $l_serverid_ref = $sth->fetchrow_hashref() or die "ERROR ----> st_shell_reconf_mgmt ----> Error while fetching the data from DB with message : " . $sth->errstr() . "\n";
 		print "WARNING ----> (st_shell_reconf_mgmt) ----> The device is handled by a distributed server or remote collector.\n",
-			"\t\t\t Please run the command 'st reconf $l_mgmt_id' on the server : $l_serverid_ref->{display_name} with IP $l_serverid_ref->{ip}.\õ";
+			"\t\t\t Please run the command 'st reconf $l_mgmt_id' on the server : $l_serverid_ref->{display_name} with IP $l_serverid_ref->{ip}.\Ãµ";
 	}
 }
 
@@ -538,6 +538,7 @@ sub print_usage {
 	"\n Usage : apg_run_script.pl -device-name <management name> [-policy-package <Name of the policy package>]\n",
 	"\t\t\t-rule-list <list of rules number>\n",
 	"\t\t\t-duration <number of days for analysis>\n",
+	"\t\t\t-userid <user ID of a valid SecureTrack user>",
 	"\t\t\t[-debug ] [-help]\n",
 	"Parameters details:\n",
 	"\trule-list \t\t : The list of rules on which the user wish to run APG on in the form \n",


### PR DESCRIPTION
Script will not function at all if -userid is not specified. Causes the following line in output:

  Use of uninitialized value $st_user in concatenation (.) or string at ./apg_run_script.pl line 499.

Traced this back to function call st_db_get_userid($userid) on line 198, which depends on line 63 and has no default value. Specifying this on the command line allows the script to execute past this point with no such error message in the output.