### PR TITLE
bug fix: uninitialized var $l_rule_uid

### DIFF
--- a/apg_run_script/apg_run_script.pl
+++ b/apg_run_script/apg_run_script.pl
@@ -346,7 +346,7 @@ sub st_shell_reconf_mgmt{
 		$sth->execute() or die "ERROR ----> st_shell_reconf_mgmt ----> Error while executing the DB query with message : " . $sth->errstr() . "\n";
 		my $l_serverid_ref = $sth->fetchrow_hashref() or die "ERROR ----> st_shell_reconf_mgmt ----> Error while fetching the data from DB with message : " . $sth->errstr() . "\n";
 		print "WARNING ----> (st_shell_reconf_mgmt) ----> The device is handled by a distributed server or remote collector.\n",
-			"\t\t\t Please run the command 'st reconf $l_mgmt_id' on the server : $l_serverid_ref->{display_name} with IP $l_serverid_ref->{ip}.\õ";
+			"\t\t\t Please run the command 'st reconf $l_mgmt_id' on the server : $l_serverid_ref->{display_name} with IP $l_serverid_ref->{ip}.\Ãµ";
 	}
 }
 
@@ -460,7 +460,7 @@ sub st_api_get_rule_uuid {
 			#Unknown Vendor
 			die "ERROR ----> Vendor not known.\n";
 		}
-		if ($l_rule_uid ne '' and $l_found_rule) {
+		if ($l_found_rule and $l_rule_uid ne '') {
 			$l_rule_uid =~ s/\{(.*)\}/$1/;
 			print "DEBUG ----> (st_api_get_rule_uuid) ----> Found rule UUID for rule number $l_rule_num : $l_rule_uid\n" if ($debug ne 0);;
 			return $l_found_rule,\$l_rule_uid;


### PR DESCRIPTION
The 'if' statement is processed in order from left to right, so if no rule is found it tries to check the uninitialized variable $l_rule_uid before checking the flag $l_found_rule. It makes more sense to check the flag first before checking the contents of a variable which might not have been set to anything under certain conditions (such as when no rule UUID was found). Rearranging the order of the 'if' statement avoids this unnecessary error; if the flag isn't set, it doesn't evaluate the second condition at all.