### PR TITLE
change 'chmod' to 'chown'

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -15,7 +15,7 @@ On the Tufin Central Server:
  - unzip libraries
  - rpm -ivh ./required-rpms/*
  - vi api.cfg and set the relevant IP addresses and user parameters
- - chmod tomcat:apache -R /opt	/tufin/securitysuite/ps/perl
+ - chown tomcat:apache -R /opt	/tufin/securitysuite/ps/perl
 
 
 Scripts available


### PR DESCRIPTION
The rest of the syntax of this line indicates it should be 'chown' not 'chmod', also nothing works with 'chmod' but everything works nicely when 'chown' is used instead.